### PR TITLE
Add copyright.txt package data using MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/snlcopyright/copyright.txt


### PR DESCRIPTION
Create MANIFEST.in file in order to have copyright.txt included in package distributions.